### PR TITLE
Add entry_point for kploy CLI

### DIFF
--- a/kploy.py
+++ b/kploy.py
@@ -534,7 +534,7 @@ def cmd_pull(param):
         print("\nYou can now `kploy pull $ID` to download and init an app.")
         print("\nWARNING: a `kploy pull $ID` will overwrite whatever you had locally.\n")
 
-if __name__ == "__main__":
+def main():
     try:
         cmds = {
             "dryrun" : cmd_dryrun,
@@ -576,3 +576,6 @@ if __name__ == "__main__":
     except (Exception) as e:
         print("Something went wrong:\n%s" %(e))
         sys.exit(1)
+
+if __name__ == "__main__":
+    main()

--- a/setup.py
+++ b/setup.py
@@ -24,8 +24,13 @@ setup(
         "Operating System :: OS Independent",
         "Programming Language :: Python",
     ],
+    entry_points={
+        "console_scripts": [
+            "kploy=kploy:main",
+        ],
+    },
     zip_safe=False,
-    packages=find_packages(),
+    py_modules=["kploy", "kploycommon"],
     install_requires=[
         "pyk",
         "tabulate"


### PR DESCRIPTION
This means we can pip install kploy, and then run it.

find_packages wasn't finding the packages, becase it only looks for
directories with **init**.py's and not for python files in the same
directory as setup.py
